### PR TITLE
Checks for the blind message generators and PoK during signing

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -449,18 +449,17 @@ Procedure:
 
 The PreBlindSign algorithm allows a holder of a signature to blind messages that when signed, are unknown to the signer.
 
-The algorithm takes in a generated blinding factor that is used to un-blind the signature from the signer, and a pedersen commitment from the generators in the signers public key PK and a vector of messages.
+The algorithm returns a generated blinding factor that is used to un-blind the signature from the signer, and a pedersen commitment from the generators in the signers public key PK and a vector of messages.
 
 ```
-(s', commitment) = PreBlindSign((msg[i],...,msg[U]), h0, (h[i],...,h[U]))
+(s', commitment) = PreBlindSign((msg[1],...,msg[U]), h0, CGens)
 ```
 
 Inputs:
 
-- msg\[i\],...,msg\[U\], octet strings of the messages to be blinded.
+- msg\[1\],...,msg\[U\], octet strings of the messages to be blinded.
 - h0, octet string.
-- h\[i\],...,h\[U\], octet strings of generators for the messages to
-    be blinded.
+- CGens, vector of octet strings of generators for the messages to be blinded
     
 Outputs:
 
@@ -469,31 +468,36 @@ Outputs:
 
 Procedure:
 
-1. s' = H(PRF(8 \* ceil(log2(r)))) mod r
+1. (Ch[1],...,Ch[U]) = CGens
 
-2. if subgroup\_check(h0) is INVALID abort
+2. s' = H(PRF(8 \* ceil(log2(r)))) mod r
 
-3. if (subgroup\_check(h\[i\]) && ... && subgroup\_check(h\[U\])) is INVALID abort
+3. if subgroup\_check(h0) is INVALID abort
 
-4. commitment = h0 \* s' + h\[i\] \* msg\[i\] + ... + h\[U\] \* msg\[U\]
+4. if (subgroup\_check(Ch\[1\]) && ... && subgroup\_check(Ch\[U\])) is INVALID abort
 
-5. return s', commitment
+5. commitment = h0 \* s' + Ch\[1\] \* msg\[1\] + ... + Ch\[U\] \* msg\[U\]
+
+6. return s', commitment
 
 ## BlindSign
 
-BlindSign generates a blind signature from a commitment received from a holder, known messages, a secret key, and generators from the corresponding public key.
+BlindSign generates a blind signature from a commitment received from a holder, known messages, a secret key, and generators from the corresponding public key. The signer also validates the commitment using the proof of knowledge of committed messages received from the holder and checks that the generators used in the commitment are not also used for the known messages.
 
 ``` 
-blind_signature = BlindSign(commitment, (msg[i],...msg[K]), SK, h0, (h[i],...,h[K]))
+blind_signature = BlindSign(commitment, (msg[1],...msg[K]), SK, h0, Gens, CGens, nizk, nonce)
 ```
 
 Inputs:
 
-- commitment, octet string receive from the holder in output form from PreBlindSign
-- msg\[i\],...,msg\[K\], octet strings
-- SK, a secret key output from KeyGen
+- commitment, octet string receive from the holder in output form PreBlindSign.
+- nizk, octet string received from the holder in output from BlindMessagesProofGen.
+- msg\[1\],...,msg\[K\], octet strings.
+- SK, a secret key output from KeyGen.
 - h0, octet string.
-- h\[i\],...,h\[K\], octet strings of generators for the known messages
+- Gens, vector of octet strings of generators for the known messages.
+- CGens, vector of octet strings of generators for the commited messages.
+- nonce, octet string, suplied to the holder by the signer to be used with BlindMessagesProofGen.
 
 Outputs:
 
@@ -501,17 +505,23 @@ Outputs:
 
 Procedure:
 
-1. e = H(PRF(8 \* ceil(log2(r)))) mod r
+1. (h[1],...,h[K]) = Gens
 
-2. s'' = H(PRF(8 \* ceil(log2(r)))) mod r
+2. e = H(PRF(8 \* ceil(log2(r)))) mod r
 
-3. b = commitment + h0 \* s'' + h\[i\] \* msg\[i\] + ... + h\[K\] \* msg\[K\]
+3. s'' = H(PRF(8 \* ceil(log2(r)))) mod r
 
-4. A = b \* (1 / (SK + e))
+4. if BlindMessagesProofVerify(commitment, nizk, CGens, nonce) is INVALID abort
 
-5. blind\_signature = (A, e, s'')
+5. if CGens intersection with Gens is not empty abort
 
-6. return blind\_signature
+6. b = commitment + h0 \* s'' + h\[1\] \* msg\[1\] + ... + h\[K\] \* msg\[K\]
+
+7. A = b \* (1 / (SK + e))
+
+8. blind\_signature = (A, e, s'')
+
+9. return blind\_signature
 
 ## UnblindSign
 
@@ -549,16 +559,16 @@ Procedure:
 BlindMessagesProofGen creates a proof of committed messages zero-knowledge proof. The proof should be verified before a signer computes a blind signature. The proof is created from a nonce given to the holder from the signer, a vector of messages, a blinding factor output from PreBlindSign, and generators from the signers public key.
 
 ```
-nizk = BlindMessagesProofGen(commitment, s', (msg[i],...,msg[U]), h0, (h[i],...,h[U]), nonce)
+nizk = BlindMessagesProofGen(commitment, s', (msg[1],...,msg[U]), h0, CGens, nonce)
 ```
 
 Inputs:
 
 - commitment, octet string as output from PreBlindSign
 - s', octet string as output from PreBlindSign
-- msg\[i\],...,msg\[U\], octet strings of the messages to be blinded.
+- msg\[1\],...,msg\[U\], octet strings of the blinded messages.
 - h0, octet string.
-- h\[i\],...,h\[U\], octet strings of generators for the messages to be blinded.
+- CGens, vector of octet strings of generators for the blinded messages.
 - nonce, octet string.
     
 Outputs:
@@ -567,34 +577,37 @@ Outputs:
 
 Procedure:
 
-1. r\~ = \[U\]
+1. (Ch[1],...,Ch[U]) = CGens
 
-2. s\~ = H(PRF(8 \* ceil(log2(r)))) mod r
+2. r\~ = \[U\]
 
-3. for i in 0 to U: r\~\[i\] = H(PRF(8 \* ceil(log2(r)))) mod r
+3. s\~ = H(PRF(8 \* ceil(log2(r)))) mod r
 
-4. U~ = h0 \* s\~ + h\[i\] \* r\~\[i\] + ... + h\[U\] \* r\~\[U\]
+4. for i in 1 to U: r\~\[i\] = H(PRF(8 \* ceil(log2(r)))) mod r
 
-5. c = H(commitment || U\~ || nonce)
+5. U~ = h0 \* s\~ + Ch\[1\] \* r\~\[1\] + ... + Ch\[U\] \* r\~\[U\]
 
-6. s^ = s\~ + c \* s'
+6. c = H(commitment || U\~ || nonce)
 
-7. r^\[i\] = r\~\[i\] + c \* msg\[i\]
+7. s^ = s\~ + c \* s'
 
-8. nizk = ( c, s^, r^ )
+8. for i in 1 to U: r^\[i\] = r\~\[i\] + c \* msg\[i\]
+
+9. nizk = ( c, s^, r^)
 
 ## BlindMessagesProofVerify
 
 BlindMessagesProofVerify checks whether a proof of committed messages zero-knowledge proof is valid.
 
 ```
-result = BlindMessagesProofVerify(commitment, nizk, nonce)
+result = BlindMessagesProofVerify(commitment, nizk, CGens, nonce)
 ```
 
 Inputs:
 
 - commitment, octet string in output form from PreBlindSign
 - nizk, octet string in output form from BlindMessagesProofGen
+- CGens, vector of octet strings of generators for the blinded messages.
 - nonce, octet string
 
 Outputs:
@@ -605,11 +618,13 @@ Procedure:
 
 1. ( c, s^, r^ ) = nizk
 
-2. U^ = commitment \* -c + h0 \* s^ + h\[i\] \* r^\[i\] + ... + h\[U\] \* r^\[U\]
+2. (Ch[1],...,Ch[U]) = CGens
 
-3. c\_v = H(U || U^ || nonce)
+3. U^ = commitment \* -c + h0 \* s^ + Ch\[1\] \* r^\[1\] + ... + Ch\[U\] \* r^\[U\]
 
-4. return c == c\_v
+4. c\_v = H(U || U^ || nonce)
+
+5. return c == c\_v
 
 ## SpkGen
 


### PR DESCRIPTION
Related to #16.

1. Added an explicit use of BlindMessageProofVerify in BlindSign to validate the PoK of committed messages, and a check that the generators used in the commitment are not also used for the known messages.
2. Changed some of the notation to accommodate those changes above. The new notation can be also used more easily if we want to add support for blind signing with multiple commitments.