### PR TITLE
Blind Sign Flow Example

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -831,4 +831,29 @@ For 128 bits security, ECDSA with curve P-256 takes 37 and 79 micro-seconds to s
 
 The signature size remains constant regardless of the number of signed messages. ECDSA and ED25519 use 32 bytes for public keys and 64 bytes for signatures. In contrast, BBS public key sizes follow the formula 48 \* (messages + 1) + 96, and 112 bytes for signatures. However, A single BBS signature is sufficient to authenticate multiple messages. We also present a method that only needs 96 bytes for the public key at the expense of a some computation before performing operations like signing, proof generation, and verification.
 
+## Blind Sign Flow Example
+
+The example below illustrates the creation of a blind signature. Let the Signer have a public key PK = (w, h0, h[1],...,h[L]) where (h[1],...,h[L]) generators. The end result will be a signature to the messages (m[1],...,m[K]) (K less than L). The messages (m[1],...,m[U]) (U less than K), will be committed by the Client using the first U generators from the Signers PK (i.e., h[1],,,,h[U]). The messages (m[U+1],...,m[K]) will be known to the Signer and will be signed using the generators (h[U+1],...,h[K]) from their PK.
+
+<pre>
++--------+                               +--------+
+|        | <-(1)------- nonce ---------> |        |
+|        |                               |        |
+| Client | --(2)- Commitment, nizk, U -> | Signer |
+|        |                               |        |
+|        | <-(3)--- Blind Signature ---- |        |
++--------+                               +--------+
+</pre>
+
+1. The Signer and the Client will agree on a nonce to be used by the BlindMessagesProofGen and BlindMessagesProofVerify functions.
+
+2. The Client will use the PreBlindSign function to calculate a Pedersen commitment for the messages (m[1],...,m[U]), using the generators (h[1],...,h[U]). Then they will create a proof of knowledge (nizk) for that commitment using BlindMessagesProofGen. The Signer will receive the commitment, the proof of knowledge (nizk) and the number of committed messages (U).
+
+3. Before sending the blinded signature to the Client the Signer must execute the following steps,
+    - Validate the proof of knowledge of the commitment using BlindMessagesProofVerify, on input the commitment, nizk, the nonce (from step 1) and the U first generators from their PK. Then check that the intersection between the generators used by the Client for the commitment, and the generators (h[U+1],...,h[K]), used by the Signer for the known messages, is indeed empty.
+    - Create the blind signature using the BlindSign function. Note that the blinded signature is not a valid BBS+ signature.
+
+    After the Client receives the blind signature they will use the UnblindSign function to unblinded it, getting a valid BBS+ signature on the messages (m[1],...,m[K]).
+
+
 {backmatter}

--- a/spec.md
+++ b/spec.md
@@ -837,7 +837,7 @@ The example below illustrates the creation of a blind signature. Let the Signer 
 
 <pre>
 +--------+                               +--------+
-|        | <-(1)------- nonce ---------> |        |
+|        | <-(1)------- nonce ---------- |        |
 |        |                               |        |
 | Client | --(2)- Commitment, nizk, U -> | Signer |
 |        |                               |        |


### PR DESCRIPTION
An example for the flow by which the Holder gets a signature with committed messages. The holder commits U messages using the first U generators from the Issuers PK.