### PR TITLE
Fixed private key domain to 0 < SK < r

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -265,7 +265,7 @@ PK = SkToPk(SK)
 
 Inputs:
 
-- SK, a secret integer such that 0 <= SK <= r
+- SK, a secret integer such that 0 < SK < r
 
 Outputs:
 


### PR DESCRIPTION
As defined in `KeyGen`, `SK` should not be `0` or `r` in `SkToPk`. The `KeyGen` definition matches selection from `Zp*` from section 4.3 of [Camenisch, Drijvers, Lehmann](https://eprint.iacr.org/2016/663.pdf).