### PR TITLE
Initial attempt to document the MapMessageToScalar function

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -691,9 +691,9 @@ a function that returns the point P corresponding to the canonical representatio
 - hash\_to\_curve\_g1:
 A cryptographic hash function that takes as an arbitrary octet string input and returns a point in G1 as defined in [@!I-D.irtf-cfrg-hash-to-curve].
 
-- hash\_to\_field: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
-
 - hash\_to\_curve\_g1\_dst: Domain separation tag used in the hash\_to\_curve\_g1 operation
+
+- hash\_to\_field: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
 
 - hash\_to\_field\_dst: Domain separation tag used in the hash\_to\_field operation
 

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -591,6 +591,33 @@ Procedure:
 3. return generators
 ```
 
+### MapMessageToScalar
+
+There are multiple ways in which messages can be mapped to their respective scalar values, which is their required form to be used with the sign, verify, spkGen and spkVerify operations.
+
+#### MapMessageToScalarAsHash
+
+This operation takes an arbitrary message and maps it to a scalar value, by hashing it to a point in the G2 subgroup for the target curve.
+
+```
+result = MapMessageToScalarAsHash(msg, dst)
+
+Inputs:
+
+- msg: octet string.
+- dst: Domain separation tag.
+
+Outputs:
+
+- result: scalar value
+
+Procedure:
+
+1. result = hash_to_curve_g2(msg, dst)
+
+2. return result
+```
+
 # Security Considerations
 
 ## Validating public keys

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -597,7 +597,7 @@ There are multiple ways in which messages can be mapped to their respective scal
 
 #### MapMessageToScalarAsHash
 
-This operation takes an arbitrary message and maps it to a scalar value, by hashing it to a point in the G2 subgroup for the target curve.
+This operation takes an arbitrary message and maps it to a scalar value, by hashing it to a point in the G1 subgroup for the target curve.
 
 ```
 result = MapMessageToScalarAsHash(msg, dst)

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -605,7 +605,7 @@ result = MapMessageToScalarAsHash(msg, dst)
 Inputs:
 
 - msg: octet string.
-- dst: Domain separation tag.
+- dst: Domain separation tag; Note this is not defined as a function argument as per [@!I-D.irtf-cfrg-hash-to-curve] instead as a parameter
 
 Outputs:
 
@@ -613,7 +613,7 @@ Outputs:
 
 Procedure:
 
-1. result = hash_to_curve_g1(msg, dst)
+1. result = hash_to_field_g1(msg, 1)
 
 2. return result
 ```
@@ -691,7 +691,9 @@ a function that returns the point P corresponding to the canonical representatio
 - hash\_to\_curve\_g1:
 A cryptographic hash function that takes as an arbitrary octet string input and returns a point in G1 as defined in [@!I-D.irtf-cfrg-hash-to-curve].
 
-- dst: Domain separation tag used in the hash\_to\_curve\_g1 operation
+- hash\_to\_field\_g1: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
+
+- dst: Domain separation tag used in the hash\_to\_curve\_g1 and hash\_to\_field\_g1 operations
 
 - message_generator_seed: The seed used to generate the message generators which form part of the public parameters used by the BBS signature scheme, Note there are multiple possible scopes for this seed including; a globally shared seed (where the resulting message generators are common across all BBS signatures); a signer specific seed (where the message generators are specific to a signer); signature specific seed (where the message generators are specific per signature). The ciphersuite MUST define this seed OR how to compute it as a pre-cursor operations to any others.
 
@@ -708,6 +710,9 @@ octets\_to\_point
 
 hash\_to\_curve_g1
 : follows the suite defined in (#bls12-381-hash-to-curve-definition-using-shake-256) for the G1 subgroup
+
+hash\_to\_field\_g1
+: adopts the required parameters from the suite defined in (#bls12-381-hash-to-curve-definition-using-shake-256) for the G1 subgroup to satisfy those described in section 5.3 [@!I-D.irtf-cfrg-hash-to-curve] along with the defined dst
 
 dst
 : "BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_"

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -693,7 +693,9 @@ A cryptographic hash function that takes as an arbitrary octet string input and 
 
 - hash\_to\_field: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
 
-- dst: Domain separation tag used in the hash\_to\_curve\_g1 and hash\_to\_field operations
+- hash\_to\_curve\_g1\_dst: Domain separation tag used in the hash\_to\_curve\_g1 operation
+
+- hash\_to\_field\_dst: Domain separation tag used in the hash\_to\_field operation
 
 - message_generator_seed: The seed used to generate the message generators which form part of the public parameters used by the BBS signature scheme, Note there are multiple possible scopes for this seed including; a globally shared seed (where the resulting message generators are common across all BBS signatures); a signer specific seed (where the message generators are specific to a signer); signature specific seed (where the message generators are specific per signature). The ciphersuite MUST define this seed OR how to compute it as a pre-cursor operations to any others.
 
@@ -711,11 +713,14 @@ octets\_to\_point
 hash\_to\_curve_g1
 : follows the suite defined in (#bls12-381-hash-to-curve-definition-using-shake-256) for the G1 subgroup
 
+hash\_to\_curve\_g1\_dst
+: "BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO"
+
 hash\_to\_field
 : adopts the required parameters from the suites defined in (#bls12-381-hash-to-curve-definition-using-shake-256) to satisfy those described in section 5.3 [@!I-D.irtf-cfrg-hash-to-curve] along with the defined dst
 
-dst
-: "BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_"
+hash\_to\_field\_dst
+: "BBS_BLS12381FQ_XOF:SHAKE-256_SSWU_RO"
 
 message_generator_seed
 : A global seed value of "BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_MESSAGE_GENERATOR_SEED" which is used by the (#creategenerators) operation to compute the required set of message generators.

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -693,7 +693,7 @@ A cryptographic hash function that takes as an arbitrary octet string input and 
 
 - hash\_to\_curve\_g1\_dst: Domain separation tag used in the hash\_to\_curve\_g1 operation
 
-- hash\_to\_field: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
+- hash\_to\_field: A cryptographic hash function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
 
 - hash\_to\_field\_dst: Domain separation tag used in the hash\_to\_field operation
 

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -613,7 +613,7 @@ Outputs:
 
 Procedure:
 
-1. result = hash_to_field_g1(msg, 1)
+1. result = hash_to_field(msg, 1)
 
 2. return result
 ```
@@ -691,9 +691,9 @@ a function that returns the point P corresponding to the canonical representatio
 - hash\_to\_curve\_g1:
 A cryptographic hash function that takes as an arbitrary octet string input and returns a point in G1 as defined in [@!I-D.irtf-cfrg-hash-to-curve].
 
-- hash\_to\_field\_g1: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
+- hash\_to\_field: A function that follows the procedure outlined in section 5.3 of [@!I-D.irtf-cfrg-hash-to-curve]
 
-- dst: Domain separation tag used in the hash\_to\_curve\_g1 and hash\_to\_field\_g1 operations
+- dst: Domain separation tag used in the hash\_to\_curve\_g1 and hash\_to\_field operations
 
 - message_generator_seed: The seed used to generate the message generators which form part of the public parameters used by the BBS signature scheme, Note there are multiple possible scopes for this seed including; a globally shared seed (where the resulting message generators are common across all BBS signatures); a signer specific seed (where the message generators are specific to a signer); signature specific seed (where the message generators are specific per signature). The ciphersuite MUST define this seed OR how to compute it as a pre-cursor operations to any others.
 
@@ -711,8 +711,8 @@ octets\_to\_point
 hash\_to\_curve_g1
 : follows the suite defined in (#bls12-381-hash-to-curve-definition-using-shake-256) for the G1 subgroup
 
-hash\_to\_field\_g1
-: adopts the required parameters from the suite defined in (#bls12-381-hash-to-curve-definition-using-shake-256) for the G1 subgroup to satisfy those described in section 5.3 [@!I-D.irtf-cfrg-hash-to-curve] along with the defined dst
+hash\_to\_field
+: adopts the required parameters from the suites defined in (#bls12-381-hash-to-curve-definition-using-shake-256) to satisfy those described in section 5.3 [@!I-D.irtf-cfrg-hash-to-curve] along with the defined dst
 
 dst
 : "BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_"

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -613,7 +613,7 @@ Outputs:
 
 Procedure:
 
-1. result = hash_to_curve_g2(msg, dst)
+1. result = hash_to_curve_g1(msg, dst)
 
 2. return result
 ```


### PR DESCRIPTION
This PR is primarily designed to help support conversation around design options we have here, it is also an extension of #61 and related to #76.

Currently for the core sign, verify, spkGen and spkVerify operations take the inputed messages as a set of octet strings so we either need to.

1. Clarify that the messages supplied here can be of abitrary value and that MapMessageToScalar becomes an operation executed within sign, verify, spkGen or spkVerify.
2. OR clarify that the messages supplied here have to be valid scalars and that MapMessageToScalar MUST be called on each message prior to calling sign, verify, spkGen or spkVerify.

The complexity we are managing is not just that the messages need to be mapped to scalars its also that they could be mapped in multiple ways (e.g message -> scalar as hash or as number) so where ever this definition occurs will also have to account for this optionality (e.g sign would not only take a list of messages to sign but the mapping method for each message)