### PR TITLE
Fixes definition of MapMessageToScalarAsHash

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -597,7 +597,7 @@ There are multiple ways in which messages can be mapped to their respective scal
 
 #### MapMessageToScalarAsHash
 
-This operation takes an arbitrary message and maps it to a scalar value, by hashing it to a point in the G1 subgroup for the target curve.
+This operation takes an input message and maps it to a scalar value for the given curve.
 
 ```
 result = MapMessageToScalarAsHash(msg, dst)

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -597,7 +597,7 @@ There are multiple ways in which messages can be mapped to their respective scal
 
 #### MapMessageToScalarAsHash
 
-This operation takes an input message and maps it to a scalar value for the given curve.
+This operation takes an input message and maps it to a scalar value via a cryptographic hash function for the given curve.
 
 ```
 result = MapMessageToScalarAsHash(msg, dst)


### PR DESCRIPTION
Fixes the in-correct definition for this operation introduced in #61 