### PR TITLE
Add definition for HASH function

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -653,7 +653,7 @@ This section defines the format for a BLS ciphersuite. It also gives concrete ci
 
 ## Ciphersuite Format
 
-- H: a cryptographic hash function.
+- HASH: a cryptographic hash function.
 
 - point\_to\_octets:
 a function that returns the canonical representation of the point P as an octet string.

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -671,7 +671,7 @@ A cryptographic hash function that takes as an arbitrary octet string input and 
 ## BLS12-381 Ciphersuite
 
 HASH
-: SHAKE-256 as defined in [@!SHA3] where the length of bytes read is ceil(log2(q)) bits, where q is the order of the subgroups G1 and G2 defined by the pairing-friendly elliptic curve
+: SHAKE-256 as defined in [@!SHA3] where the length of bytes drawn from it is dependent on the operation (32 bytes when used in the context of the KeyGen operation and 64 bytes when used in the context of SpkGen)
 
 XOF
 : SHAKE-256 as defined in [@!SHA3]

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -671,7 +671,7 @@ A cryptographic hash function that takes as an arbitrary octet string input and 
 ## BLS12-381 Ciphersuite
 
 HASH
-: SHAKE-256 as defined in [@!SHA3] where the length of bytes drawn from it is dependent on the operation (32 bytes when used in the context of the KeyGen operation and 64 bytes when used in the context of SpkGen)
+: SHAKE-256 as defined in [@!SHA3] where the length of bytes drawn from it is 32 bytes.
 
 XOF
 : SHAKE-256 as defined in [@!SHA3]

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -247,7 +247,7 @@ Procedure:
 
 3. while SK == 0:
 
-4.     salt = H(salt)
+4.     salt = HASH(salt)
 
 5.     PRK = HKDF-Extract(salt, IKM || I2OSP(0, 1))
 
@@ -670,7 +670,10 @@ A cryptographic hash function that takes as an arbitrary octet string input and 
 
 ## BLS12-381 Ciphersuite
 
-H
+HASH
+: SHAKE-256 as defined in [@!SHA3] where the length of bytes read is ceil(log2(q)) bits, where q is the order of the subgroups G1 and G2 defined by the pairing-friendly elliptic curve
+
+XOF
 : SHAKE-256 as defined in [@!SHA3]
 
 point\_to\_octets


### PR DESCRIPTION
We currently use a HASH function separate to how we use an XOF function in the KeyGen SpkGen and SpkVerify functions, this provides an updated definition resolving H -> HASH instead of having two notations to describe the same thing AND provides a concrete definition for the BLS12-381 cipher suite including how many bytes we draw for the operations.