### PR TITLE
Adding revealed messages to challenge hash

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -505,6 +505,7 @@ Inputs:
 - msg_1,..., msg_L, octet strings. Messages in input to Sign.
 - H_1,..., H_L, points of G1. The generators in input to Sign.
 - RevealedIndexes, vector of unsigned integers. Indexes of revealed messages.
+                   RevealedIndexes MUST be ordered from the lowest to the highest value.
 - signature, octet string in output form from Sign.
 - header, an optional octet string containing context and application specific
           information. If not supplied, it defaults to an empty string.
@@ -591,6 +592,7 @@ Inputs:
 - msg_i1,..., msg_iR, octet strings. The revealed messages in input to ProofGen.
 - H_1,..., H_L, points of G1. The generators in input to Sign.
 - RevealedIndexes, vector of unsigned integers. Indexes of revealed messages.
+                   RevealedIndexes MUST be ordered from the lowest to the highest value.
 - header, an optional octet string containing context and application specific
           information. If not supplied, it defaults to an empty string.
 - ph, octet string

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -505,7 +505,7 @@ Inputs:
 - msg_1,..., msg_L, octet strings. Messages in input to Sign.
 - H_1,..., H_L, points of G1. The generators in input to Sign.
 - RevealedIndexes, vector of unsigned integers. Indexes of revealed messages.
-                   RevealedIndexes MUST be ordered from the lowest to the highest value.
+                   This vector MUST be ordered from the lowest to the highest value.
 - signature, octet string in output form from Sign.
 - header, an optional octet string containing context and application specific
           information. If not supplied, it defaults to an empty string.

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -534,45 +534,47 @@ Procedure:
 
 6. generators =  (H_s || H_d || H_1 || ... || H_L)
 
-7. domain = OS2IP(HASH(PK || L || generators || Ciphersuite_ID || header)) mod q
+7. revealed_msgs = (msg_i1 || msg_i2 || ... || msg_iR)
 
-8. for element in (r1, r2, e~, r2~, r3~, s~, m~_j1, ..., m~_jU):
+8. domain = OS2IP(HASH(PK || L || generators || Ciphersuite_ID || header)) mod q
 
-9.      element = HASH(PRF(8*ceil(log2(q)))) mod q
+9. for element in (r1, r2, e~, r2~, r3~, s~, m~_j1, ..., m~_jU):
 
-10.      if element = 0, go back to step 7
+10.      element = HASH(PRF(8*ceil(log2(q)))) mod q
 
-11. B = P1 + H_s * s + H_d * domain + H_1 * msg_1 + ... + H_L * msg_L
+11.      if element = 0, go back to step 7
 
-12. r3 = r1 ^ -1 mod q
+12. B = P1 + H_s * s + H_d * domain + H_1 * msg_1 + ... + H_L * msg_L
 
-13. A' = A * r1
+13. r3 = r1 ^ -1 mod q
 
-14. Abar = A' * (-e) + B * r1
+14. A' = A * r1
 
-15. D = B * r1 + H_s * r2
+15. Abar = A' * (-e) + B * r1
 
-16. s' = s + r2 * r3
+16. D = B * r1 + H_s * r2
 
-17. C1 = A' * e~ + H_s * r2~
+17. s' = s + r2 * r3
 
-18. C2 = D * (-r3~) + H_s * s~ + H_j1 * m~_j1 + ... + H_jU * m~_jU
+18. C1 = A' * e~ + H_s * r2~
 
-19. c = HASH(PK || Abar || A' || D || C1 || C2 || ph)
+19. C2 = D * (-r3~) + H_s * s~ + H_j1 * m~_j1 + ... + H_jU * m~_jU
 
-20. e^ = e~ + c * e
+20. c = HASH(PK || Abar || A' || D || C1 || C2 || domain || revealed_msgs || ph)
 
-21. r2^ = r2~ + c * r2
+21. e^ = e~ + c * e
 
-22. r3^ = r3~ + c * r3
+22. r2^ = r2~ + c * r2
 
-23. s^ = s~ + c * s'
+23. r3^ = r3~ + c * r3
 
-24. for j in (j1, j2,..., jU): m^_j = m~_j + c * msg_j
+24. s^ = s~ + c * s'
 
-25. proof = ( A', Abar, D, c, e^, r2^, r3^, s^, (m^_j1, ..., m^_jU))
+25. for j in (j1, j2,..., jU): m^_j = m~_j + c * msg_j
 
-26. return proof
+26. proof = ( A', Abar, D, c, e^, r2^, r3^, s^, (m^_j1, ..., m^_jU))
+
+27. return proof
 ```
 
 ### ProofVerify
@@ -615,23 +617,25 @@ Procedure:
 
 5. generators =  (H_s || H_d || H_1 || ... || H_L)
 
-6. domain = OS2IP(HASH(PK || L || generators || Ciphersuite_ID || header)) mod q
+6. revealed_msgs = (msg_i1 || msg_i2 || ... || msg_iR)
 
-7. C1 = (Abar - D) * c + A' * e^ + H_s * r2^
+7. domain = OS2IP(HASH(PK || L || generators || Ciphersuite_ID || header)) mod q
 
-8. T = P1 + H_s * domain + H_i1 * msg_i1 + ... H_iR * msg_iR
+8. C1 = (Abar - D) * c + A' * e^ + H_s * r2^
 
-9. C2 = T * c + D * (-r3^) + H_s * s^ + H_j1 * m^_j1 + ... + H_jU * m^_jU
+9. T = P1 + H_s * domain + H_i1 * msg_i1 + ... H_iR * msg_iR
 
-10. cv = HASH(PK || Abar || A' || D || C1 || C2 || ph)
+10. C2 = T * c + D * (-r3^) + H_s * s^ + H_j1 * m^_j1 + ... + H_jU * m^_jU
 
-11. if c != cv return INVALID
+11. cv = HASH(PK || Abar || A' || D || C1 || C2 || domain || revealed_msgs || ph)
 
-12. if A' == 1 return INVALID
+12. if c != cv return INVALID
 
-13. if e(A', W) * e(Abar, -P2) != 1 return INVALID
+13. if A' == 1 return INVALID
 
-14. return VALID
+14. if e(A', W) * e(Abar, -P2) != 1 return INVALID
+
+15. return VALID
 ```
 
 ### CreateGenerators

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -592,7 +592,7 @@ Inputs:
 - msg_i1,..., msg_iR, octet strings. The revealed messages in input to ProofGen.
 - H_1,..., H_L, points of G1. The generators in input to Sign.
 - RevealedIndexes, vector of unsigned integers. Indexes of revealed messages.
-                   RevealedIndexes MUST be ordered from the lowest to the highest value.
+                   This vector MUST be ordered from the lowest to the highest value.
 - header, an optional octet string containing context and application specific
           information. If not supplied, it defaults to an empty string.
 - ph, octet string

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -560,7 +560,7 @@ Procedure:
 
 19. C2 = D * (-r3~) + H_s * s~ + H_j1 * m~_j1 + ... + H_jU * m~_jU
 
-20. c = HASH(PK || Abar || A' || D || C1 || C2 || domain || revealed_msgs || ph)
+20. c = HASH(Abar || A' || D || C1 || C2 || R || revealed_msgs || domain || ph)
 
 21. e^ = e~ + c * e
 
@@ -627,7 +627,7 @@ Procedure:
 
 10. C2 = T * c + D * (-r3^) + H_s * s^ + H_j1 * m^_j1 + ... + H_jU * m^_jU
 
-11. cv = HASH(PK || Abar || A' || D || C1 || C2 || domain || revealed_msgs || ph)
+11. cv = HASH(Abar || A' || D || C1 || C2 || R || revealed_msgs || domain || ph)
 
 12. if c != cv return INVALID
 


### PR DESCRIPTION
Closes #74 

Adding the revealed messages as well as the signature domain value to the challenge hash in ProofGen and ProofVerify.