### PR TITLE
API update

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -389,15 +389,14 @@ Procedure:
 This operation computes a deterministic signature from a secret key (SK) and optionally over a header and or a vector of messages.
 
 ```
-signature = Sign(SK, PK, header, (msg_1,..., msg_L), (H_1,..., H_L))
+signature = Sign(SK, PK, header, [(H_1, msg_1),..., (H_L, msg_L)])
 
 Inputs:
 
 - SK (REQUIRED), an octet string of the form outputted by the KeyGen operation.
 - PK (REQUIRED), an octet string of the form outputted by the SkToPk operation provided the above SK as input.
 - header (OPTIONAL), an octet string containing context and application specific information. If not supplied, it defaults to an empty string.
-- msg_1,..., msg_L (OPTIONAL), a vector of octet strings.
-- H_1,..., H_L (OPTIONAL), points of G1. Generators used to commit each message.
+- [(H_1, msg_1),..., (H_L, msg_L)] (OPTIONAL), a list with pairs of the form (point in G1, scalar). Generators and messages pairs, corresponding to messages to be signed. If not supplied, it will default to the empty array ("[]"). The list MUST be ordered based on the values of the generators  (i.e., H_1 < H_2 < ... < H_L).
 
 Parameters:
 
@@ -447,15 +446,14 @@ Procedure:
 This operation checks that a signature is valid for a given header and vector of messages against a supplied public key (PK).
 
 ```
-result = Verify(PK, signature, header, (msg_1,..., msg_L), (H_1,..., H_L))
+result = Verify(PK, signature, header, [(H_1, msg_1),..., (H_L, msg_L)])
 
 Inputs:
 
 - PK (REQUIRED), an octet string of the form outputted by the SkToPk operation.
 - signature (REQUIRED), an octet string of the form outputted by the Sign operation.
 - header (OPTIONAL), an octet string containing context and application specific information. If not supplied, it defaults to an empty string.
-- msg_1,..., msg_L (OPTIONAL), an optional vector of octet strings.
-- H_1,..., H_L (OPTIONAL), points of G1. Generators used to commit each message.
+- [(H_1, msg_1),..., (H_L, msg_L)] (OPTIONAL), a list with pairs of the form (point in G1, scalar). Generators and messages pairs, corresponding to signed messages. If not supplied, it will default to the empty array ("[]"). The list MUST be ordered based on the values of the generators (i.e., H_1 < H_2 < ... < H_L).
 
 Parameters:
 
@@ -498,22 +496,28 @@ Procedure:
 
 ### ProofGen
 
-This operation computes a zero-knowledge proof-of-knowledge of a signature, while optionally selectively disclosing from the original set of signed messages. The "prover" may also supply a presentation header, see [presentation header selection](#presentation-header-selection) for more details.
-
-If an application chooses to pass the indexes of the generators instead, then it will also need to pass the indexes of the generators corresponding to the revealed messages.
+This operation computes a zero-knowledge proof-of-knowledge of a signature, while optionally selectively disclosing from the original set of signed messages. The "prover" may also supply a presentation header, see [presentation header selection](#presentation-header-selection) for more details. The generators and messages are supplied as pairs in two different lists: the first list containing (generator, message) pairs with signed messages that will be revealed, and the second list containing (generator, message) pairs corresponding to the signed messages that will be kept hidden. The union of those two lists MUST equal the list of (generator, message) pairs supplied to Sign (i.e., the second list MUST contain all (generator, message) pairs corresponding to signed messages that do not appear in the first list).
 
 ```
-proof = ProofGen(PK, signature, header, ph, (msg_1,..., msg_L), (H_1,..., H_L), RevealedIndexes)
+proof = ProofGen(PK, signature,
+                 [(H_i1, msg_i1), ..., (H_iR, msg_iR)], 
+                 [(H_h1, msg_h1), ..., (H_hU, msg_hU)],
+                 header, ph)
 
 Inputs:
 
 - PK (REQUIRED), an octet string of the form outputted by the SkToPk operation.
 - signature (REQUIRED), an octet string of the form outputted by the Sign operation.
+- [(H_i1, msg_i1), ..., (H_iR, msg_iR)] (REQUIRED), Generators and message pairs 
+                                        corresponding to messages to be revealed. 
+                                        Generators must be G1 points, and the 
+                                        messages must be non-zero scalars mod q.
+- [(H_h1, msg_h1), ..., (H_hU, msg_hU)] (REQUIRED), Generators and messages pairs 
+                                        corresponding to messages to be kept hidden. 
+                                        Generators must be G1 points, and the 
+                                        messages must be non-zero scalars mod q.
 - header (OPTIONAL), an octet string containing context and application specific information. If not supplied, it defaults to an empty string.
 - ph (OPTIONAL), octet string.
-- msg_1,..., msg_L (OPTIONAL), octet strings. Messages in input to Sign.
-- H_1,..., H_L (OPTIONAL), points of G1. The generators in input to Sign.
-- RevealedIndexes (OPTIONAL), vector of unsigned integers. Indexes of revealed messages.
 
 Parameters:
 
@@ -524,7 +528,8 @@ Parameters:
 Definitions:
 
 - L, is the non-negative integer representing the number of messages to be signed e.g length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
-- R, is the non-negative integer representing the number of revealed messages e.g length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- R, is the non-negative integer representing the number of revealed messages e.g length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).H
+- [(H_1, msg_1), ..., (H_L, msg_L)], is the concatenation of the list [(H_i1, msg_i1), ..., (H_iR, msg_iR)] (the input list corresponding to revealed messages) and the list [(H_h1, msg_h1), ..., (H_hU, msg_hU)] (the input list corresponding to un-revealed messages). The two lists MUST have an empty intersection and their union MUST equal [(H_1, msg_1) ..., (H_L, msg_L)] (the list in input to Sign). The resulting list MUST be ordered based on the generators (i.e., H_1 < H_2 < ... < H_L).
 
 Outputs:
 
@@ -534,57 +539,53 @@ Procedure:
 
 1. signature_result = octets_to_signature(signature)
 
-2. (i1, i2,..., iR) = RevealedIndexes
+2. if signature_result is INVALID, return INVALID
 
-3. (j1, j2,..., jU) = [L] \ RevealedIndexes
+3. (A, e, s) = signature_result
 
-4. if signature_result is INVALID, return INVALID
+4. if KeyValidate(PK) is INVALID, return INVALID
 
-5. (A, e, s) = signature_result
+5. generators = (H_s || H_d || H_1 || ... || H_L)
 
-6. if KeyValidate(PK) is INVALID, return INVALID
+6. domain = OS2IP(hash(PK || L || generators || Ciphersuite_ID || header)) mod q
 
-7. generators =  (H_s || H_d || H_1 || ... || H_L)
+7. for element in (r1, r2, e~, r2~, r3~, s~, m~_1, ..., m~_U):
 
-8. domain = OS2IP(hash(PK || L || generators || Ciphersuite_ID || header)) mod q
+8.      element = hash(PRF(8*ceil(log2(q)))) mod q
 
-9. for element in (r1, r2, e~, r2~, r3~, s~, m~_j1, ..., m~_jU):
+9.      if element = 0, go back to step 7
 
-10.      element = hash(PRF(8*ceil(log2(q)))) mod q
+10. B = P1 + H_s * s + H_d * domain + H_1 * msg_1 + ... + H_L * msg_L
 
-11.      if element = 0, go back to step 7
+11. r3 = r1 ^ -1 mod q
 
-12. B = P1 + H_s * s + H_d * domain + H_1 * msg_1 + ... + H_L * msg_L
+12. A' = A * r1
 
-13. r3 = r1 ^ -1 mod q
+13. Abar = A' * (-e) + B * r1
 
-14. A' = A * r1
+14. D = B * r1 + H_s * r2
 
-15. Abar = A' * (-e) + B * r1
+15. s' = s + r2 * r3
 
-16. D = B * r1 + H_s * r2
+16. C1 = A' * e~ + H_s * r2~
 
-17. s' = s + r2 * r3
+17. C2 = D * (-r3~) + H_s * s~ + H_h1 * m~_1 + ... + H_hU * m~_U
 
-18. C1 = A' * e~ + H_s * r2~
+18. c = hash(PK || Abar || A' || D || C1 || C2 || ph)
 
-19. C2 = D * (-r3~) + H_s * s~ + H_j1 * m~_j1 + ... + H_jU * m~_jU
+19. e^ = e~ + c * e
 
-20. c = hash(PK || Abar || A' || D || C1 || C2 || ph)
+20. r2^ = r2~ + c * r2
 
-21. e^ = e~ + c * e
+21. r3^ = r3~ + c * r3
 
-22. r2^ = r2~ + c * r2
+22. s^ = s~ + c * s'
 
-23. r3^ = r3~ + c * r3
+23. for j in (1, 2,..., U): m^_j = m~_j + c * msg_j
 
-24. s^ = s~ + c * s'
+24. proof = (A', Abar, D, c, e^, r2^, r3^, s^, (m^_j1, ..., m^_jU))
 
-25. for j in (j1, j2,..., jU): m^_j = m~_j + c * msg_j
-
-26. proof = (A', Abar, D, c, e^, r2^, r3^, s^, (m^_j1, ..., m^_jU))
-
-27. return proof
+25. return proof
 ```
 
 ### ProofVerify
@@ -592,17 +593,23 @@ Procedure:
 This operation checks that a proof is valid for a header, vector of revealed messages (along side their index corresponding to their original position when signed) and presentation header against a public key (PK).
 
 ```
-result = ProofVerify(PK, proof, ph, header, (msg_i1,..., msg_iR), RevealedIndexes, (H_1,..., H_L))
+result = ProofVerify(PK, proof, ph          
+                 [(H_i1, msg_i1), ..., (H_iR, msg_iR)], 
+                 [H_h1, ..., H_hU],
+                 header)
 
 Inputs:
 
 - PK (REQUIRED), an octet string of the form outputted by the SkToPk operation.
 - proof (REQUIRED), an octet string of the form outputted by the ProofGen operation.
 - ph (REQUIRED), octet string.
+- [(H_i1, msg_i1), ..., (H_iR, msg_iR)] (REQUIRED), Generators and message pairs 
+                                        corresponding to messages to be revealed. 
+                                        Generators must be G1 points, and the 
+                                        messages must be non-zero scalars mod q.
+- H_h1, ..., H_hU (REQUIRED), points of G1. Generators corresponding to messages 
+                              to be kept hidden.
 - header (OPTIONAL), an optional octet string containing context and application specific information. If not supplied, it defaults to an empty string.
-- msg_i1,..., msg_iR (OPTIONAL), octet strings. The revealed messages in input to ProofGen.
-- RevealedIndexes (OPTIONAL), vector of unsigned integers. Indexes of revealed messages.
-- H_1,..., H_L (OPTIONAL), points of G1. The generators in input to Sign.
 
 Parameters:
 
@@ -614,6 +621,7 @@ Definitions:
 
 - L, is the non-negative integer representing the number of messages to be signed e.g length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
 - R, is the non-negative integer representing the number of revealed messages e.g length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- [H_1, ..., H_L], is the concatenation of the list [H_i1, ..., H_iR] (the list of generators corresponding to revealed messages) and the list [H_h1, ..., H_hU] (the input generators list corresponding to un-revealed messages). The two lists MUST have an empty intersection and their union MUST equal [H_1 ..., H_L] (the list of generators appearing in the input to Sign list with the (generator, message) pairs). The list MUST be ordered based on the generator values (i.e., H_1 <= H_2 <= ... <= H_L).
 
 Outputs:
 
@@ -623,31 +631,27 @@ Procedure:
 
 1. if KeyValidate(PK) is INVALID, return INVALID
 
-2. (i1, i2, ..., iR) = RevealedIndexes
+2. (A', Abar, D, c, e^, r2^, r3^, s^, (m^_1,...,m^_U)) = proof
 
-3. (j1, j2, ..., jU) = [L]\RevealedIndexes
+3. generators =  (H_s || H_d || H_1 || ... || H_L)
 
-4. (A', Abar, D, c, e^, r2^, r3^, s^, (m^_j1,...,m^_jU)) = proof
+4. domain = OS2IP(hash(PK || L || generators || Ciphersuite_ID || header)) mod q
 
-5. generators =  (H_s || H_d || H_1 || ... || H_L)
+5. C1 = (Abar - D) * c + A' * e^ + H_s * r2^
 
-6. domain = OS2IP(hash(PK || L || generators || Ciphersuite_ID || header)) mod q
+6. T = P1 + H_s * domain + H_i1 * msg_i1 + ... H_iR * msg_iR
 
-7. C1 = (Abar - D) * c + A' * e^ + H_s * r2^
+7. C2 = T * c + D * (-r3^) + H_s * s^ + H_h1 * m^_1 + ... + H_hU * m^_U
 
-8. T = P1 + H_s * domain + H_i1 * msg_i1 + ... H_iR * msg_iR
+8. cv = hash(PK || Abar || A' || D || C1 || C2 || ph)
 
-9. C2 = T * c + D * (-r3^) + H_s * s^ + H_j1 * m^_j1 + ... + H_jU * m^_jU
+10. if c != cv, return INVALID
 
-10. cv = hash(PK || Abar || A' || D || C1 || C2 || ph)
+11. if A' == 1, return INVALID
 
-11. if c != cv, return INVALID
+12. if e(A', W) * e(Abar, -P2) != 1, return INVALID
 
-12. if A' == 1, return INVALID
-
-13. if e(A', W) * e(Abar, -P2) != 1, return INVALID
-
-14. return VALID
+13. return VALID
 ```
 
 ### CreateGenerators


### PR DESCRIPTION
Updating the way that the messages and generators are passed to the operations, using @andrewwhitehead's proposal of passing them in pairs. 

The main purpose of the PR is to have a concrete base of discussion about what the best API will be. For alternatives see #117. For some more context see PR #128 (the motivation was “how we get the revealed messages from the (msg_1, …, msg_L) list and the revealed indexes).

IMO all approaches have trade-offs. Although I like the proposal seen in this PR a lot and it makes things more explicit, I wonder if it is more error prone?? That said, it may provide the best balance between being explicit and easy to read. Interested on the WG feedback.
