### PR TITLE
Add definition of U to ProofGen/ProofVerify

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -547,8 +547,9 @@ Parameters:
 
 Definitions:
 
-- L, is the non-negative integer representing the number of messages to be signed e.g length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
-- R, is the non-negative integer representing the number of revealed messages e.g length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- L, is the non-negative integer representing the number of messages to be signed, i.e., L = length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
+- R, is the non-negative integer representing the number of revealed messages, i.e., R = length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- U, is the non-negative integer representing the number of hidden messages, i.e., U = L - R.
 
 Outputs:
 
@@ -634,8 +635,9 @@ Parameters:
 
 Definitions:
 
-- L, is the non-negative integer representing the number of messages to be signed e.g length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
-- R, is the non-negative integer representing the number of revealed messages e.g length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- L, is the non-negative integer representing the number of messages to be signed, i.e., L = length(msg_1,...,msg_L). Note if no messages are supplied as an input to this operation, the value of L MUST evaluate to zero (0).
+- R, is the non-negative integer representing the number of revealed messages, i.e., R = length(RevealedIndexes). Note if no revealed messages are supplied as an input to this operation, the value of R MUST evaluate to zero (0).
+- U, is the non-negative integer representing the number of hidden messages, i.e., U = L - R.
 
 Outputs:
 


### PR DESCRIPTION
Suggesting adding `U` to the definitions, since the value is used in the functions. 

Also changed "e.g." to "i.e." as a clarification. 