### PR TITLE
Order points in hash and update 1 to Identity_GT

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -553,7 +553,7 @@ Procedure:
 
 17. C2 = D * (-r3~) + H_s * s~ + H_j1 * m~_1 + ... + H_jU * m~_U
 
-18. c = hash_to_scalar((PK || Abar || A' || D || C1 || C2 || ph), 1)
+18. c = hash_to_scalar((PK || A' || Abar || D || C1 || C2 || ph), 1)
 
 19. e^ = e~ + c * e
 
@@ -629,7 +629,7 @@ Procedure:
 
 12. C2 = T * c + D * (-r3^) + H_s * s^ + H_j1 * m^_1 + ... + H_jU * m^_U
 
-13. cv = hash_to_scalar((PK || Abar || A' || D || C1 || C2 || ph), 1)
+13. cv = hash_to_scalar((PK || A' || Abar || D || C1 || C2 || ph), 1)
 
 14. if c != cv, return INVALID
 

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -477,7 +477,7 @@ Procedure:
 
 8. B = P1 + H_s * s + H_d * domain + H_1 * msg_1 + ... + H_L * msg_L
 
-9. if e(A, W + P2 * e) * e(B, -P2) != 1, return INVALID
+9. if e(A, W + P2 * e) * e(B, -P2) != Identity_GT, return INVALID
 
 10. return VALID
 ```


### PR DESCRIPTION
Fixes #173 by @dev0x1.
Now the challenge hashes `c` and `cv` in `ProofGen` and `ProofVerify` are computed as `hash_to_scalar((PK || A' || Abar || D || C1 || C2 || ph), 1)`, to keep the ordering of the proof.

The other minor fix is to follow the new notation introduced in #175  and use `Identity_GT` instead of `1` in `Verify`.