### PR TITLE
Fix and add links

### DIFF
--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -1176,8 +1176,6 @@ Secret keys MAY be generated using other methods; in this case they MUST be infe
 
 BBS proofs are nondeterministic, meaning care must be taken against attacks arising from using bad randomness, for example, the nonce reuse attack on ECDSA [@HDWH12]. It is RECOMMENDED that the presentation header used in this specification contain a nonce chosen at random from a trusted source of randomness, see the (#presentation-header-selection) for additional considerations.
 
-BlindSign as discussed in 2.10 uses randomness from two parties so care MUST be taken that both sources of randomness are trusted. If one party uses weak randomness, it could compromise the signature.
-
 When a trusted source of randomness is used, signatures and proofs are much harder to forge or break due to the use of multiple nonces.
 
 ## Presentation header selection

--- a/draft-bbs-signatures.md
+++ b/draft-bbs-signatures.md
@@ -297,7 +297,7 @@ The schemes operations defined in this section depend on the following parameter
 
 * A pairing-friendly elliptic curve, plus associated functionality given in [Section 1.2](#notation).
 
-* hash, a hash function that MUST be a secure cryptographic hash function. For security, hash MUST output at least `ceil(log2(r))` bits, where r is the order of the subgroups G1 and G2 defined by the pairing-friendly elliptic curve. See [encoding of elements to be hashed](#encoding-of-elements-to-be-hashed) for details on how the inputs to the function must be encoded.
+* hash, a hash function that MUST be a secure cryptographic hash function. For security, hash MUST output at least `ceil(log2(r))` bits, where r is the order of the subgroups G1 and G2 defined by the pairing-friendly elliptic curve. See [Encoding of elements to be hashed](#encoding-of-elements-to-be-hashed) for details on how the inputs to the function must be encoded.
 
 * xof, a cryptographically secure extendable-output function like SHAKE128 or SHAKE256. xof outputs any desirable amount of bytes using the `.read(int)` method. See [Encoding of elements to be hashed](#encoding-of-elements-to-be-hashed) for details on how the inputs to the function must be encoded.
 
@@ -517,7 +517,7 @@ Procedure:
 
 ### ProofGen
 
-This operation computes a zero-knowledge proof-of-knowledge of a signature, while optionally selectively disclosing from the original set of signed messages. The "prover" may also supply a presentation header, see [presentation header selection](#presentation-header-selection) for more details.
+This operation computes a zero-knowledge proof-of-knowledge of a signature, while optionally selectively disclosing from the original set of signed messages. The "prover" may also supply a presentation header, see [Presentation header selection](#presentation-header-selection) for more details.
 
 The messages supplied in this operation MUST be in the same order as when supplied to [Sign](#sign). To specify which of those messages will be disclosed, the prover can supply the list of indexes (`disclosedIndexes`) that the disclosed messages have in the array of signed messages. Each element in `disclosedIndexes` MUST be a non-negative integer, in the range from 1 to `length(messages)`.
 
@@ -641,7 +641,7 @@ Procedure:
 
 This operation checks that a proof is valid for a header, vector of disclosed messages (along side their index corresponding to their original position when signed) and presentation header against a public key (PK).
 
-The operation accepts the list of messages the prover indicated to be disclosed. Those messages MUST be in the same order as when supplied to [Sign](#sign) (as a subset of the signed messages list). The operation also requires the total number of signed messages (L). Lastly, it also accepts the indexes that the disclosed messages had in the original array of messages supplied to [Sign](#sign) (i.e., the `disclosedIndexes` list supplied to [ProodGen](#proofgen)). Every element in this list MUST be a non-negative integer in the range from 1 to L, in ascending order.
+The operation accepts the list of messages the prover indicated to be disclosed. Those messages MUST be in the same order as when supplied to [Sign](#sign) (as a subset of the signed messages list). The operation also requires the total number of signed messages (L). Lastly, it also accepts the indexes that the disclosed messages had in the original array of messages supplied to [Sign](#sign) (i.e., the `disclosedIndexes` list supplied to [ProofGen](#proofgen)). Every element in this list MUST be a non-negative integer in the range from 1 to L, in ascending order.
 
 ```
 result = ProofVerify(PK, proof, L, header, ph,
@@ -751,7 +751,7 @@ Procedure:
 
 ## Generator point computation
 
-The `create_generators` operation defines how to create a set of generators that form a part of the public parameters used by the BBS Signature scheme to accomplish operations such as Sign, Verify, ProofGen and ProofVerify. It takes one input, the number of generator points to create, which is determined in part by the number of signed messages.
+The `create_generators` operation defines how to create a set of generators that form a part of the public parameters used by the BBS Signature scheme to accomplish operations such as [Sign](#sign), [Verify](#verify), [ProofGen](#proofgen) and [ProofVerify](#proofverify). It takes one input, the number of generator points to create, which is determined in part by the number of signed messages.
 
 As an optimization, implementations MAY cache the result of `create_generators` for a specific `generator_seed` (determined by the ciphersuite) and `count`. The values `n` and `v` MAY also be cached in order to efficiently extend a existing list of generator points.
 
@@ -815,7 +815,7 @@ Procedure:
 
 ## MapMessageToScalar
 
-There are multiple ways in which messages can be mapped to their respective scalar values, which is their required form to be used with the Sign, Verify, ProofGen and ProofVerify operations.
+There are multiple ways in which messages can be mapped to their respective scalar values, which is their required form to be used with the [Sign](#sign), [Verify](#verify), [ProofGen](#proofgen) and [ProofVerify](#proofverify) operations.
 
 ### MapMessageToScalarAsHash
 
@@ -850,7 +850,7 @@ Procedure:
 
 ## Hash to Scalar
 
-This operation describes how to hash an arbitrary octet string to `n` scalar values in the multiplicative group of integers mod r (i.e., values in the range [1, r-1]).  This procedure acts as a helper function, used internally in various places within the operations described in the spec. To map a message to a scalar that would be passed as input to the [Sign](#sign), [Verify](#verify), [ProofGen](#proofgen) and [ProofVerify](#proofgen) functions, one must use [MapMessageToScalarAsHash](#mapmessagetoscalar) instead.
+This operation describes how to hash an arbitrary octet string to `n` scalar values in the multiplicative group of integers mod r (i.e., values in the range [1, r-1]).  This procedure acts as a helper function, used internally in various places within the operations described in the spec. To map a message to a scalar that would be passed as input to the [Sign](#sign), [Verify](#verify), [ProofGen](#proofgen) and [ProofVerify](#proofverify) functions, one must use [MapMessageToScalarAsHash](#mapmessagetoscalar) instead.
 
 This operation makes use of expand\_message defined in [@!I-D.irtf-cfrg-hash-to-curve], in a similar way used by the hash\_to\_field operation of Section 5 from the same document (with the additional checks for getting a scalar that is 0). Note that, if an implementer wants to use hash\_to\_field instead, they MUST use the multiplicative group of integers mod r (Fr), as the target group (F). However, the hash\_to\_curve ciphersuites used by this document, make use of hash\_to\_field with the target group being the multiplicative group of integers mod p (Fp). For completeness, we define here the operation making use of the expand\_message function, that will be defined by the hash-to-curve suite used. If someone also has a hash\_to\_field implementation available, with the target group been Fr, they can use this instead (adding the check for a scalar been 0).
 
@@ -961,8 +961,8 @@ Procedure:
 
 This operation describes how to encode a signature to an octet string.
 
-*Note* this operation deliberately does not perform the relevant checks on the inputs `A` `e` and `s`
-because its assumed these are done prior to its invocation, e.g as is the case with the Sign operation.
+*Note* this operation deliberately does not perform the relevant checks on the inputs `A`, `e` and `s`
+because its assumed these are done prior to its invocation, e.g as is the case with the [Sign](#sign) operation.
 
 ```
 signature_octets = signature_to_octets(signature)
@@ -1154,11 +1154,11 @@ It is RECOMENDED for any operation in [Core Operations](#core-operations) involv
 
 ## Point de-serialization
 
-This document makes use of `octet_to_point_g*` to parse octet strings to elliptic curve points (either in G1 or G2). It is assumed (even if not explicitly described) that the result of this operation will not be INVALID. If `octet_to_point_g*` returns INVALID, then the calling operation should immediately return INVALID as well and abort the operation. Note that the only place where the output is assumed to be VALID implicitly is in the [Encoding of Elements to be Hashed](#encoding-of-elements-to-be-hashed) section.
+This document makes use of `octet_to_point_g*` to parse octet strings to elliptic curve points (either in G1 or G2). It is assumed (even if not explicitly described) that the result of this operation will not be INVALID. If `octet_to_point_g*` returns INVALID, then the calling operation should immediately return INVALID as well and abort the operation. Note that the only place where the output is assumed to be VALID implicitly is in the [Encoding of elements to be hashed](#encoding-of-elements-to-be-hashed) section.
 
 ## Skipping membership checks
 
-Some existing implementations skip the subgroup\_check invocation in Verify (#verify), whose purpose is ensuring that the signature is an element of a prime-order subgroup.  This check is REQUIRED of conforming implementations, for two reasons.
+Some existing implementations skip the subgroup\_check invocation in [Verify](#verify), whose purpose is ensuring that the signature is an element of a prime-order subgroup.  This check is REQUIRED of conforming implementations, for two reasons.
 
 1.  For most pairing-friendly elliptic curves used in practice, the pairing operation e (#notation) is undefined when its input points are not in the prime-order subgroups of E1 and E2. The resulting behavior is unpredictable, and may enable forgeries.
 


### PR DESCRIPTION
Very little contribution but I hope it is helpful.
- Fixed existing links (removing typos, whitespaces, capitalizing first letter, ...)
- Added missing links to operations
- Removed an old paragraph about BlindSign