### PR TITLE
Create generators flexibility

### DIFF
--- a/draft-irtf-cfrg-bbs-signatures.md
+++ b/draft-irtf-cfrg-bbs-signatures.md
@@ -1256,7 +1256,7 @@ The following section defines the format of the unique identifier for the cipher
 
   *  H2C\_SUITE\_ID is the suite ID of the hash-to-curve suite used to define the hash_to_curve function.
 
-  *  CG\_ID is the ID of the create generators used, i.e., `CREATE_GENERATORS_ID` as defined in the [Create Generators](#generator-point-computation) section.
+  *  CG\_ID is the ID of the create generators used, i.e., `CREATE_GENERATORS_ID` as defined in the (#generators-calculation) section.
 
   *  ADD\_INFO is an optional octet string indicating any additional information used to uniquely qualify the ciphersuite. When present this value MUST only contain ASCII encoded characters with codes between 0x21 and 0x7e (inclusive) and MUST end with an underscore (ASCII code: 0x5f), other than the last character the string MUST not contain any other underscores (ASCII code: 0x5f).
 
@@ -1292,7 +1292,7 @@ a function that returns the point P in the subgroup G2 corresponding to the cano
 
 **Generator parameters**:
 
-- create\_generators: the operation with which to create a set of generators. See (#generator-point-computation).
+- create\_generators: the operation with which to create a set of generators. See (#generators-calculation).
 
 ## BLS12-381 Ciphersuites
 

--- a/draft-irtf-cfrg-bbs-signatures.md
+++ b/draft-irtf-cfrg-bbs-signatures.md
@@ -390,6 +390,8 @@ Parameters:
                   specified by the hash_to_curve_suite parameter.
 - octet_scalar_length, non-negative integer. The length of a scalar
                        octet representation, defined by the ciphersuite.
+- create_generators, an operation that returns a number of generator
+                     points, defined by the ciphersuite.
 
 Definitions:
 
@@ -450,6 +452,8 @@ Inputs:
 Parameters:
 
 - P1, fixed point of G1, defined by the ciphersuite.
+- create_generators, an operation that returns a number of generator
+                     points, defined by the ciphersuite.
 
 Definitions:
 
@@ -514,6 +518,8 @@ Inputs:
 Parameters:
 
 - P1, fixed point of G1, defined by the ciphersuite.
+- create_generators, an operation that returns a number of generator
+                     points, defined by the ciphersuite.
 
 Definitions:
 
@@ -603,6 +609,8 @@ Inputs:
 Parameters:
 
 - P1, fixed point of G1, defined by the ciphersuite.
+- create_generators, an operation that returns a number of generator
+                     points, defined by the ciphersuite.
 
 Definitions:
 

--- a/draft-irtf-cfrg-bbs-signatures.md
+++ b/draft-irtf-cfrg-bbs-signatures.md
@@ -782,7 +782,7 @@ When defining a new `create_generators` procedure, the most important property i
 - The returned points must be different from the Identity point of G1 as well as the constant point `P1` defined by the ciphersuite.
 - Must be constant time for a specific `count` value.
 - MUST be deterministic.
-- Must use proper domain separation for both the `create_generator` procedure, as well as all the internally called procedures.
+- Must use proper domain separation for both the `create_generators` procedure, as well as all of the internally-called procedures.
 
 ## Message to Scalar
 


### PR DESCRIPTION
Closes #206

Going with option 2 from the issue, allowing the definition of new `create_generators` and listing the relative requirements. Τhis will also benefit use cases like [Bound signatures](https://github.com/decentralized-identity/bbs-signature/issues/262).