### PR TITLE
Update draft-irtf-cfrg-bbs-signatures.md

### DIFF
--- a/draft-irtf-cfrg-bbs-signatures.md
+++ b/draft-irtf-cfrg-bbs-signatures.md
@@ -739,7 +739,7 @@ Deserialization:
 Procedure:
 
 1. random_scalars = calculate_random_scalars(3+U)
-2. init_res = ProofInit(PK, signature_res, generators, random_scalars,
+2. init_res = ProofInit(PK, signature_result, generators, random_scalars,
                           header, messages, undisclosed_indexes, api_id)
 3. if init_res is INVALID, return INVALID
 4. challenge = ProofChallengeCalculate(init_res, disclosed_indexes,


### PR DESCRIPTION
## Possible typo
In section 3.6.3.  CoreProofGen I noticed that "signature_result" became "signature_res" and fixed that. Specifically

```
2. init_res = ProofInit(PK, signature_res, generators, random_scalars,
                          header, messages, undisclosed_indexes, api_id)
```

If it is not a typo and there is a reason for that, close this pull request.